### PR TITLE
Add a FileTreeWidget which shows filesystem objects in a tree

### DIFF
--- a/adventurebuddy/__init__.py
+++ b/adventurebuddy/__init__.py
@@ -1,2 +1,13 @@
+import os
+import sys
+
+from PySide6.QtWidgets import QApplication
+
+from . import ui
+
+
 def run():
-    print("This is the GUI entrypoint!")
+    app = QApplication(sys.argv)
+    ftw = ui.FileTreeWidget(os.getcwd())
+    ftw.show()
+    sys.exit(app.exec())

--- a/adventurebuddy/ui/__init__.py
+++ b/adventurebuddy/ui/__init__.py
@@ -1,0 +1,1 @@
+from .filetreewidget import FileTreeWidget

--- a/adventurebuddy/ui/filetreewidget.py
+++ b/adventurebuddy/ui/filetreewidget.py
@@ -1,0 +1,53 @@
+import pathlib
+
+from PySide6.QtWidgets import QTreeWidget, QTreeWidgetItem, QWidget
+
+
+class FileTreeWidget(QTreeWidget):
+    def __init__(self, path: pathlib.Path | str, parent: QWidget = None):
+        """A widget which holds entries from the filesystem as a tree.
+
+        Parameters
+        ----------
+        path : pathlib.Path | str
+            Path to search for filesystem objects
+        parent : QWidget
+            The parent of this widget
+        """
+        super().__init__(parent)
+        self.root = pathlib.Path(path)
+        self.refresh()
+
+    def refresh(self):
+        """Clear out the FileTreeWidget, and repopulate it with objects from the filesystem."""
+        self.clear()
+        self.addTopLevelItems(self.items_from_path(self.root))
+
+    def items_from_path(self, path: pathlib.Path) -> list[QTreeWidgetItem]:
+        """Generate a list of item widgets for each filesystem object from the given path.
+
+        The result is sorted, with directories coming before files.
+
+        Parameters
+        ----------
+        path : pathlib.Path
+            Path to recurse through for filesystem objects
+
+        Returns
+        -------
+        list[QTreeWidgetItem]
+            List of widgets to populate the file tree
+        """
+        files = []
+        directories = []
+        for item in path.iterdir():
+            entry = QTreeWidgetItem(None, [str(item.relative_to(self.root))])
+            if item.is_file():
+                files.append(entry)
+            elif item.is_dir():
+                entry.addChildren(self.items_from_path(item))
+                directories.append(entry)
+            else:
+                raise ValueError("Unknown file type encountered")
+
+        return sorted(directories) + sorted(files)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,25 @@ packages = ["adventurebuddy"]
 [tool.ruff]
 line-length = 100
 
+[tool.ruff.lint]
+select = [
+  # pycodestyle
+  "E",
+  # Pyflakes
+  "F",
+  # pyupgrade
+  "UP",
+  # flake8-bugbear
+  "B",
+  # flake8-simplify
+  "SIM",
+  # isort
+  "I",
+]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
+
 [project.optional-dependencies]
 dev = ["pre-commit", "ruff-lsp", "python-lsp-server"]
 


### PR DESCRIPTION
This PR adds a `FileTreeWidget` which shows filesystem objects in a tree.

- I also modified the `__init__.py` for the project so I could test it out by running `adventurebuddy` from the command line, but I can remove this if it you want. 
- I updated the rules for the linter to include a bunch of common rules that we probably want enabled. I ignored F401 for `__init__.py` files though (that's the one that complains about unused import statements) because that's often what `__init__.py` is used for.